### PR TITLE
Support pullable sources

### DIFF
--- a/readme.js
+++ b/readme.js
@@ -44,8 +44,8 @@ const combine = (...sources) => (start, sink) => {
   const vals = new Array(n);
   const sourceTalkbacks = new Array(n);
   const talkback = (t, d) => {
-    if (t !== 2) return;
-    for (let i = 0; i < n; i++) sourceTalkbacks[i](2);
+    if (t === 0) return;
+    for (let i = 0; i < n; i++) sourceTalkbacks[i](t, d);
   };
   sources.forEach((source, i) => {
     vals[i] = EMPTY;


### PR DESCRIPTION
Although I'm not sure they should be supported, the behaviour is somewhat confusing, for a simple case of:
```js
pipe(
  combine(
    fromIter([1, 2, 3]),
    fromIter(10, 20, 30),
  ),
  forEach(vals => console.log(vals))
)
```
we get:
```js
[1, 10]
[2, 10]
[3, 10]
[3, 20]
[3, 30]
```
OTOH pullable source doesn't have to respond with a value synchronously, so maybe it's ok.

General question: not sure who should do the data request? only the sink and filtering operators? should maybe `combine` send 1 upward after initialization is completed?